### PR TITLE
Fixed dependencies

### DIFF
--- a/EAPM/plugin.meta
+++ b/EAPM/plugin.meta
@@ -12,7 +12,8 @@
     "numpy",
     "matplotlib",
     "seaborn",
-    "bsc_calculations",
-    "prepare_proteins"
+    "mdtraj",
+    "git+https://github.com/Martin-Floor/bsc_calculations.git",
+    "git+https://github.com/Martin-Floor/prepare_proteins.git"
   ]
 }


### PR DESCRIPTION
Modified the plugin.meta file in order to correctly fetch all dependencies

- `mdtraj` was missing
- `bsc_calculations` and `prepare_proteins` are not available on PyPi, but can be downloaded directly from the repos