### PR TITLE
Froze biopython version to 1.81

### DIFF
--- a/EAPM/plugin.meta
+++ b/EAPM/plugin.meta
@@ -6,7 +6,7 @@
   "pluginFile": "EAPM.py",
   "dependencies": [
     "pandas",
-    "biopython",
+    "biopython==1.81",
     "scipy",
     "pyyaml",
     "numpy",


### PR DESCRIPTION
Biopython 1.82 removed `Bio.PDB.Polypeptide.one_to_three` which is needed in the prepare_proteins library